### PR TITLE
feat: run migrations on deploy via docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY alembic.ini ./
 COPY alembic alembic/
 COPY oopsie oopsie/
 COPY templates templates/
+COPY docker-entrypoint.sh ./
 
 RUN chown -R oopsie:oopsie /app
 USER oopsie
@@ -29,4 +30,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["uvicorn", "oopsie.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+alembic upgrade head
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Adds `docker-entrypoint.sh` that runs `alembic upgrade head` before starting the app server
- Updates `Dockerfile` to use the entrypoint, ensuring database schema is up to date on each deployment

## Test plan
- [ ] Deploy to Railway and verify migrations run before the app starts
- [ ] Verify app starts normally after migrations complete
- [ ] Verify healthcheck still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)