### PR TITLE
fix: copy static directory into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY alembic.ini ./
 COPY alembic alembic/
 COPY oopsie oopsie/
 COPY templates templates/
+COPY static static/
 COPY docker-entrypoint.sh ./
 
 RUN chown -R oopsie:oopsie /app


### PR DESCRIPTION
## Summary
- Adds missing `COPY static static/` to Dockerfile, fixing startup crash due to missing static files directory

## Test plan
- [ ] Deploy to Railway and verify app starts without `Directory 'static' does not exist` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)