### PR TITLE
fix: copy run_worker.py into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY alembic alembic/
 COPY oopsie oopsie/
 COPY templates templates/
 COPY static static/
+COPY run_worker.py ./
 COPY docker-entrypoint.sh ./
 
 RUN chown -R oopsie:oopsie /app

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+echo "Running database migrations..."
 alembic upgrade head
+echo "Migrations complete."
 
 exec "$@"


### PR DESCRIPTION
## Summary
- Adds missing `COPY run_worker.py ./` to Dockerfile so the worker service can find its entry point
- Adds echo statements to docker-entrypoint.sh for migration debugging

## Test plan
- [ ] Deploy worker service and verify it starts without `No such file or directory` error
- [ ] Verify migrations log output in deploy logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)