### PR TITLE
fix: use dynamic PORT env var for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
-CMD ["uvicorn", "oopsie.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]
+CMD uvicorn oopsie.main:app --host 0.0.0.0 --port ${PORT:-8000} --no-access-log


### PR DESCRIPTION
## Summary
- Changes Dockerfile CMD to use `${PORT:-8000}` so Railway's dynamic port assignment works
- Falls back to port 8000 for local development

## Test plan
- [ ] Deploy to Railway and verify the public URL serves the app
- [ ] Verify local `docker build && docker run` still works on port 8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)