### PR TITLE
fix: add proxy headers middleware for Railway OAuth

### DIFF
--- a/oopsie/main.py
+++ b/oopsie/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from oopsie.api.errors import router as errors_router
 from oopsie.auth_routes import router as auth_router
@@ -50,6 +51,7 @@ _session_secret = _settings.jwt_secret_key or secrets.token_urlsafe(32)
 app.add_middleware(SessionMiddleware, secret_key=_session_secret)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.add_middleware(RequestLoggingMiddleware)
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["*"])
 
 app.include_router(auth_router, tags=["auth"])
 app.include_router(errors_router, prefix="/api/v1/errors", tags=["errors"])


### PR DESCRIPTION
## Summary
- Adds `ProxyHeadersMiddleware` so the app correctly sees `https://` when behind Railway's reverse proxy
- Fixes the Google OAuth `redirect_uri_mismatch` error caused by the app generating `http://` callback URLs

## Test plan
- [ ] Deploy to Railway and verify Google OAuth login works without redirect_uri_mismatch
- [ ] Verify local development still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)