### PR TITLE
fix: enable pool_pre_ping for stale DB connections

### DIFF
--- a/oopsie/database.py
+++ b/oopsie/database.py
@@ -29,6 +29,7 @@ def _adapt_url_for_asyncpg(url: str) -> str:
 engine = create_async_engine(
     _adapt_url_for_asyncpg(get_settings().database_url),
     echo=False,
+    pool_pre_ping=True,
 )
 async_session_factory = async_sessionmaker(
     engine,


### PR DESCRIPTION
## Summary
- Adds `pool_pre_ping=True` to the SQLAlchemy async engine configuration
- Fixes "connection is closed" errors on Railway where managed Postgres closes idle connections after a timeout
- SQLAlchemy now pings each connection before checkout, transparently replacing dead ones

## Test plan
- [ ] Deploy to Railway and verify login via Google OAuth works without "connection is closed" errors
- [ ] Verify the app handles idle periods gracefully (leave idle, then trigger a request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)